### PR TITLE
Change end of /LIST response to 323, as defined in IRC RFC (was 321)

### DIFF
--- a/rdircd
+++ b/rdircd
@@ -1000,7 +1000,7 @@ class IRCProtocol:
 			names = self.bridge.cmd_chan_names(c.name)
 			topic = str_repr(c.topic, max_len=self.conf.irc_len_topic, len_bytes=True)
 			self.send(322, self.chan_spec(c.name), len(names), f':{topic}')
-		self.send(321, ':End of /LIST')
+		self.send(323, ':End of /LIST')
 
 	def recv_cmd_motd(self, target=None): self.send_motd()
 


### PR DESCRIPTION
/LIST is presently sending 321 for the end of list response, when per the RFC (Kalt, Internet Relay Chat: Client Protocol, RFC 2812, p. 44) it should be returning 323.

When returning 321 (labelled "Obsolete. Not used" in the above RFC), /LIST was not reliable in either mIRC or AdiIRC, the first request would be incomplete, and subsequent LIST requests were ignored without reconnecting.  Additionally, the ZNC route_requests plugin would immediately complain it couldn't finish the listing request.

