### PR TITLE
replace walrus operator

### DIFF
--- a/rdircd
+++ b/rdircd
@@ -2049,8 +2049,8 @@ class DiscordSession:
 		if act == 'update': tags['_prefix'] = tags.get('_prefix', '') + self.conf.irc_prefix_edit
 		else:
 			flake = m.id
-			if ( self.conf.irc_inline_reply_quote_len > 0
-					and (ref := m.get('referenced_message')) ):
+			ref = m.get('referenced_message')
+			if self.conf.irc_inline_reply_quote_len > 0 and ref:
 				ref_user = ref.get('author', dict()).get('username')
 				ref_user = f'<{ref_user}>' if ref_user else ''
 				ref = ref.content.strip() if ref.content else ''


### PR DESCRIPTION
Python 3.8 [introduced](https://docs.python.org/3/whatsnew/3.8.html) the `:=` (walrus) operator which was added to this project in commit 37c436a, rendering my instance unable to start under Python 3.7 after updating. With this patch, I am able to see inline replies.

```
[21:30:52] <zimmedon> test
[21:31:10] <zimmedon> -- re:<zimmedon> test
[21:31:10] <zimmedon> test again
```