### PR TITLE
Adds c_chan_type 13 for new stage channels

### DIFF
--- a/rdircd
+++ b/rdircd
@@ -1352,6 +1352,7 @@ class DiscordSession:
 		group = 4 # header for a group of channels
 		news = 5 # announcements channels
 		store = 6
+		stage = 13
 
 	class c_msg_type(enum.IntEnum):
 		default = 0


### PR DESCRIPTION
Wasn't able to login due to a missing 13 in the c_chan_type enum.  After debugging, they are the new "stage" channels and I've added them to the list of types.