### PR TITLE
Setting MODE +v doesn't work in some clients (mIRC, AdiIRC, HexChat) without sending :server first

### DIFF
--- a/rdircd
+++ b/rdircd
@@ -995,7 +995,7 @@ class IRCProtocol:
 		self.send(f':{self.st.nick} JOIN {chan}')
 		self.send_topic(chan, c=c)
 		self.send_names(chan, own=True, c=c)
-		self.send(f'MODE {chan} +v {self.st.nick}')
+		self.send(0, f'MODE {chan} +v {self.st.nick}')
 		self.st.chans.add(name)
 
 	def recv_cmd_part(self, chan, reason=None):


### PR DESCRIPTION
This is something I missed in #9 originally (which has been improved since) and I have been adding in myself manually for a while.  Tested against AdiIRC, HexChat, and irssi.